### PR TITLE
New `linkcode_resolve`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Changed `linkcode_resolve` to point to the exact git revision.
+
 ### Removed
 
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-COMPAS Association
+Copyright (c) 2023 COMPAS Association
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/sphinx_compas2_theme/__init__.py
+++ b/src/sphinx_compas2_theme/__init__.py
@@ -1,11 +1,8 @@
 from __future__ import print_function
 
 from pathlib import Path
-import importlib
-import inspect
 import sys
 import re
-
 
 __author__ = ["tom van mele"]
 __copyright__ = "COMPAS Association"
@@ -55,49 +52,6 @@ default_mock_imports = [
     "bmesh",
     "mathutils",
 ]
-
-
-def get_linkcode_resolve(organization, repo):
-    def linkcode_resolve(domain, info):
-        if domain != "py":
-            return None
-        if not info["module"]:
-            return None
-        if not info["fullname"]:
-            return None
-
-        package = info["module"].split(".")[0]
-        if not package.startswith(repo):
-            return None
-
-        module = importlib.import_module(info["module"])
-        parts = info["fullname"].split(".")
-
-        if len(parts) == 1:
-            obj = getattr(module, info["fullname"])
-            mod = inspect.getmodule(obj)
-            if not mod:
-                return None
-            filename = mod.__name__.replace(".", "/")
-            lineno = inspect.getsourcelines(obj)[1]
-        elif len(parts) == 2:
-            obj_name, attr_name = parts
-            obj = getattr(module, obj_name)
-            attr = getattr(obj, attr_name)
-            if inspect.isfunction(attr):
-                mod = inspect.getmodule(attr)
-                if not mod:
-                    return None
-                filename = mod.__name__.replace(".", "/")
-                lineno = inspect.getsourcelines(attr)[1]
-            else:
-                return None
-        else:
-            return None
-
-        return f"https://github.com/{organization}/{repo}/blob/main/src/{filename}.py#L{lineno}"
-
-    return linkcode_resolve
 
 
 def get_latest_version():

--- a/src/sphinx_compas2_theme/__init__.py
+++ b/src/sphinx_compas2_theme/__init__.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 from pathlib import Path
 import sys
 import re
+from sphinx_compas2_theme.linkcode import make_linkcode_resolve
 
 __author__ = ["tom van mele"]
 __copyright__ = "COMPAS Association"
@@ -52,6 +53,14 @@ default_mock_imports = [
     "bmesh",
     "mathutils",
 ]
+
+
+def get_linkcode_resolve(
+    organization,
+    package,
+    url_fmt="https://github.com/{organization}/{package}/blob/{revision}/src/{package}/{path}#L{lineno}",
+):
+    return make_linkcode_resolve(package, organization, url_fmt)
 
 
 def get_latest_version():

--- a/src/sphinx_compas2_theme/linkcode.py
+++ b/src/sphinx_compas2_theme/linkcode.py
@@ -65,7 +65,7 @@ def _linkcode_resolve(domain, info, package, organization, url_fmt, revision):
     ...                   url_fmt="https://github.com/{organization}/{package}/blob/"
     ...                           "{revision}/src/{package}/{path}#L{lineno}",
     ...                   revision="1663ec7")
-    "https://github.com/compas-dev/compas/blob/1663ec7/src/compas/colors/color.py#L28"
+    'https://github.com/compas-dev/compas/blob/1663ec7/src/compas/colors/color.py#L28'
     """
 
     if revision is None:

--- a/src/sphinx_compas2_theme/linkcode.py
+++ b/src/sphinx_compas2_theme/linkcode.py
@@ -58,14 +58,13 @@ def _linkcode_resolve(domain, info, package, organization, url_fmt, revision):
     This is called by sphinx.ext.linkcode
 
     An example with a long-untouched module that everyone has
-    >>> _linkcode_resolve('py', {'module': 'tty',
-    ...                          'fullname': 'setraw'},
-    ...                   package='tty',
-    ...                   organization='cpython',
-    ...                   url_fmt='http://hg.python.org/{organization}/file/'
-    ...                           '{revision}/Lib/{package}/{path}#L{lineno}',
-    ...                   revision='xxxx')
-    'http://hg.python.org/cpython/file/xxxx/Lib/tty/tty.py#L18'
+    >>> _linkcode_resolve("py", {"module": "compas.colors",
+    ...                          "fullname": "Color"},
+    ...                   package="compas",
+    ...                   organization="compas-dev",
+    ...                   url_fmt="https://github.com/{organization}/{package}/blob/{revision}/src/{package}/{path}#L{lineno}",
+    ...                   revision="1663ec7")
+    "https://github.com/compas-dev/compas/blob/1663ec7/src/compas/colors/color.py#L28"
     """
 
     if revision is None:

--- a/src/sphinx_compas2_theme/linkcode.py
+++ b/src/sphinx_compas2_theme/linkcode.py
@@ -95,7 +95,7 @@ def _linkcode_resolve(domain, info, package, organization, url_fmt, revision):
     if not fn:
         return
 
-    fn = os.path.relpath(fn, start=os.path.dirname(__import__(package).__file__))
+    fn = os.path.relpath(fn, start=os.path.dirname(__import__(package).__file__)).replace("\\", "/")
     try:
         lineno = inspect.getsourcelines(obj)[1]
     except Exception:

--- a/src/sphinx_compas2_theme/linkcode.py
+++ b/src/sphinx_compas2_theme/linkcode.py
@@ -62,7 +62,8 @@ def _linkcode_resolve(domain, info, package, organization, url_fmt, revision):
     ...                          "fullname": "Color"},
     ...                   package="compas",
     ...                   organization="compas-dev",
-    ...                   url_fmt="https://github.com/{organization}/{package}/blob/{revision}/src/{package}/{path}#L{lineno}",
+    ...                   url_fmt="https://github.com/{organization}/{package}/blob/"
+    ...                           "{revision}/src/{package}/{path}#L{lineno}",
     ...                   revision="1663ec7")
     "https://github.com/compas-dev/compas/blob/1663ec7/src/compas/colors/color.py#L28"
     """

--- a/src/sphinx_compas2_theme/linkcode.py
+++ b/src/sphinx_compas2_theme/linkcode.py
@@ -52,7 +52,7 @@ def _get_git_revision():
     return revision.decode("utf-8")
 
 
-def _linkcode_resolve(domain, info, package, url_fmt, revision):
+def _linkcode_resolve(domain, info, package, organization, url_fmt, revision):
     """Determine a link to online source for a class/method/function
 
     This is called by sphinx.ext.linkcode
@@ -61,7 +61,8 @@ def _linkcode_resolve(domain, info, package, url_fmt, revision):
     >>> _linkcode_resolve('py', {'module': 'tty',
     ...                          'fullname': 'setraw'},
     ...                   package='tty',
-    ...                   url_fmt='http://hg.python.org/cpython/file/'
+    ...                   organization='cpython',
+    ...                   url_fmt='http://hg.python.org/{organization}/file/'
     ...                           '{revision}/Lib/{package}/{path}#L{lineno}',
     ...                   revision='xxxx')
     'http://hg.python.org/cpython/file/xxxx/Lib/tty/tty.py#L18'
@@ -99,19 +100,19 @@ def _linkcode_resolve(domain, info, package, url_fmt, revision):
         lineno = inspect.getsourcelines(obj)[1]
     except Exception:
         lineno = ""
-    return url_fmt.format(revision=revision, package=package, path=fn, lineno=lineno)
+    return url_fmt.format(revision=revision, package=package, organization=organization, path=fn, lineno=lineno)
 
 
-def make_linkcode_resolve(package, url_fmt):
+def make_linkcode_resolve(package, organization, url_fmt):
     """Returns a linkcode_resolve function for the given URL format
 
     revision is a git commit reference (hash or name)
 
     package is the name of the root module of the package
 
-    url_fmt is along the lines of ('https://github.com/USER/PROJECT/'
+    url_fmt is along the lines of ('https://github.com/{organization}/PROJECT/'
                                    'blob/{revision}/{package}/'
                                    '{path}#L{lineno}')
     """
     revision = _get_git_revision()
-    return partial(_linkcode_resolve, revision=revision, package=package, url_fmt=url_fmt)
+    return partial(_linkcode_resolve, revision=revision, package=package, organization=organization, url_fmt=url_fmt)

--- a/src/sphinx_compas2_theme/linkcode.py
+++ b/src/sphinx_compas2_theme/linkcode.py
@@ -1,0 +1,117 @@
+"""This module is adapted from the scikit-learn project, licensed under the BSD 3-Clause License.
+
+https://github.com/scikit-learn/scikit-learn/
+
+BSD 3-Clause License
+
+Copyright (c) 2007-2023 The scikit-learn developers.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+"""
+import inspect
+import os
+import subprocess
+import sys
+from functools import partial
+from operator import attrgetter
+
+REVISION_CMD = "git rev-parse --short HEAD"
+
+
+def _get_git_revision():
+    try:
+        revision = subprocess.check_output(REVISION_CMD.split()).strip()
+        print("GIT Revision is {}".format(revision))
+    except (subprocess.CalledProcessError, OSError):
+        print("Failed to execute git to get revision")
+        return None
+    return revision.decode("utf-8")
+
+
+def _linkcode_resolve(domain, info, package, url_fmt, revision):
+    """Determine a link to online source for a class/method/function
+
+    This is called by sphinx.ext.linkcode
+
+    An example with a long-untouched module that everyone has
+    >>> _linkcode_resolve('py', {'module': 'tty',
+    ...                          'fullname': 'setraw'},
+    ...                   package='tty',
+    ...                   url_fmt='http://hg.python.org/cpython/file/'
+    ...                           '{revision}/Lib/{package}/{path}#L{lineno}',
+    ...                   revision='xxxx')
+    'http://hg.python.org/cpython/file/xxxx/Lib/tty/tty.py#L18'
+    """
+
+    if revision is None:
+        return
+    if domain not in ("py", "pyx"):
+        return
+    if not info.get("module") or not info.get("fullname"):
+        return
+
+    class_name = info["fullname"].split(".")[0]
+    module = __import__(info["module"], fromlist=[class_name])
+    obj = attrgetter(info["fullname"])(module)
+
+    # Unwrap the object to get the correct source
+    # file in case that is wrapped by a decorator
+    obj = inspect.unwrap(obj)
+
+    try:
+        fn = inspect.getsourcefile(obj)
+    except Exception:
+        fn = None
+    if not fn:
+        try:
+            fn = inspect.getsourcefile(sys.modules[obj.__module__])
+        except Exception:
+            fn = None
+    if not fn:
+        return
+
+    fn = os.path.relpath(fn, start=os.path.dirname(__import__(package).__file__))
+    try:
+        lineno = inspect.getsourcelines(obj)[1]
+    except Exception:
+        lineno = ""
+    return url_fmt.format(revision=revision, package=package, path=fn, lineno=lineno)
+
+
+def make_linkcode_resolve(package, url_fmt):
+    """Returns a linkcode_resolve function for the given URL format
+
+    revision is a git commit reference (hash or name)
+
+    package is the name of the root module of the package
+
+    url_fmt is along the lines of ('https://github.com/USER/PROJECT/'
+                                   'blob/{revision}/{package}/'
+                                   '{path}#L{lineno}')
+    """
+    revision = _get_git_revision()
+    return partial(_linkcode_resolve, revision=revision, package=package, url_fmt=url_fmt)


### PR DESCRIPTION
New implementation of `linkcode_resolve`, adapted from `scikit-learn`'s implementation. It fixes a number of things, in particular, it matches exactly the git version in the current environment, so the source link always points to the correct location.

From a `conf.py` file, it can be used exactly as it's currently used, with the additional option that the url format string can be customized.

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [x] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
